### PR TITLE
Fix VNA measurments and optional Smith charts.

### DIFF
--- a/examples/calculateVNA_900M.py
+++ b/examples/calculateVNA_900M.py
@@ -14,6 +14,7 @@ measName = sys.argv[1]
 
 saveFig = False
 plotFig = False
+smithFig = False
 if len(sys.argv) == 3:
     if sys.argv[2] == "plot":
         plotFig = True
@@ -24,6 +25,13 @@ if len(sys.argv) == 3:
 if plotFig:
     from matplotlib.pyplot import *
     import warnings
+    try:
+      import smithplot
+      from smithplot import SmithAxes
+      smithFig = True
+    except:
+      print("pySmithPlot not found, smith chart will be not displayed")
+
 
     warnings.filterwarnings("ignore", module="matplotlib")
 
@@ -160,14 +168,15 @@ if plotFig:
         savefig(measName + '_s11.png')
     show()
 
-    figure(figsize=(24, 16))
-    subplot(1, 1, 1, projection='smith', grid_major_fancy=True,
-            grid_minor_fancy=True, plot_hacklines=True)
-    ZDutPlot = filterData(freq, ZDut, fMin, fMax)
-    plot(ZDutPlot, markevery=1, label="S11", color='b', linewidth=1.5, aa=True)
-    if saveFig:
-        savefig(measName + '_smith.png')
-    show()
+    if smithFig:
+        figure(figsize=(8, 8))
+        subplot(1, 1, 1, projection='smith', grid_major_fancy=True,
+                grid_minor_fancy=True, plot_marker_hack=True)
+        ZDutPlot = filterData(freq, ZDut, fMin, fMax)
+        plot(50 * ZDutPlot, markevery=1, markersize=4.0, label="S11", color='b', linewidth=1.5, aa=True, datatype=SmithAxes.Z_PARAMETER)
+        if saveFig:
+            savefig(measName + '_smith.png')
+        show()
 
 outFileName = measName + '.s1p'
 outFile = open(outFileName, 'w')

--- a/examples/measureVNA.py
+++ b/examples/measureVNA.py
@@ -3,14 +3,25 @@ import numpy
 import sys
 from pyLMS7002Soapy import pyLMS7002Soapy as pyLMSS
 
-if len(sys.argv) != 2:
-    print("Usage: python measureVNA.py measurementName")
+if len(sys.argv) < 2:
+    print("Usage: python measureVNA.py measurementName [startFreq Mhz] [endFreq Mhz] [stepFreq Mhz]")
     exit(1)
 
 startFreq = 2.30e9
-endFreq = 2.6e9
-nPoints = 101
+endFreq   = 2.6e9
+stepFreq  =  3e6
 measName = sys.argv[1]
+
+if len(sys.argv) == 5:
+  startFreq = int(float(sys.argv[2]) * 1e6)
+  endFreq   = int(float(sys.argv[3]) * 1e6)
+  stepFreq  = int(float(sys.argv[4]) * 1e6)
+
+nPoints =  int( (endFreq - startFreq) / 1e6 ) + 1
+
+print ("")
+print ("Using startFreq=%i endFreq=%i stepFreq=%i (nPoints=%i)" % (startFreq, endFreq, stepFreq, nPoints) )
+print ("")
 
 LNA = 'LNAH'
 
@@ -126,7 +137,7 @@ def adjustRxGain(lms7002):
         RFE.G_LNA_RFE = lnaGain
         if mcuRSSI() < 50e3:
             pgaGain += pgaStep
-        pgaStep = pgaStep / 2
+        pgaStep = int(pgaStep / 2)
 
     #    pgaGain = 16
     #    lnaGain = 8

--- a/examples/measureVNA_900M.py
+++ b/examples/measureVNA_900M.py
@@ -4,14 +4,25 @@ import numpy
 import os, sys
 from pyLMS7002Soapy import pyLMS7002Soapy as pyLMSS
 
-if len(sys.argv) != 2:
-    print("Usage: python measureVNA_900M.py measurementName")
+if len(sys.argv) < 2:
+    print("Usage: python measureVNA_900M.py measurementName [startFreq Mhz] [endFreq Mhz] [stepFreq Mhz]")
     exit(1)
 
-startFreq = 800e6
-endFreq = 1000e6
-nPoints = 201
+startFreq =  800e6
+endFreq   =  1000e6
+stepFreq  =  1e6
 measName = sys.argv[1]
+
+if len(sys.argv) == 5:
+  startFreq = int(float(sys.argv[2]) * 1e6)
+  endFreq   = int(float(sys.argv[3]) * 1e6)
+  stepFreq  = int(float(sys.argv[4]) * 1e6)
+
+nPoints =  int( (endFreq - startFreq) / 1e6 ) + 1
+
+print ("")
+print ("Using startFreq=%i endFreq=%i stepFreq=%i (nPoints=%i)" % (startFreq, endFreq, stepFreq, nPoints) )
+print ("")
 
 
 #################################################
@@ -125,7 +136,7 @@ def adjustRxGain(lms7002):
         RFE.G_LNA_RFE = lnaGain
         if mcuRSSI() < 50e3:
             pgaGain += pgaStep
-        pgaStep = pgaStep / 2
+        pgaStep = int(pgaStep / 2)
 
     RBB.G_PGA_RBB = pgaGain
     RFE.G_LNA_RFE = lnaGain


### PR DESCRIPTION

  Proposed PR fix the VNA measurement scripts and Smith chart display. 

- Fix a float->int register casting (slowdown bug).
- VNA scripts accept custom ranges from CLI.
- Smith charts are optional and conditioned to pySmithPlot library is detection.
- Smith chart properly display values in accord to impedances (no more shifts).


Thank you !